### PR TITLE
Added Windows Terminal as a requirement in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ All posts will save to and be served from the backend over a REST API.
 
 
 # Getting Started
-You will need NodeJs and npm installed.
+You will need NodeJs, npm, and Windows Terminal installed.
 Clone the repo and then run the "Runny Runner" shortcut.


### PR DESCRIPTION
# Overview
I forgot that I wrote the runner to utilize the new Windows Terminal. It won't work without it because it makes calls to "wt"